### PR TITLE
feat(components): Add Filter component

### DIFF
--- a/src/components/Form/Filter/Filter.jsx
+++ b/src/components/Form/Filter/Filter.jsx
@@ -1,0 +1,16 @@
+import { Label, InputField } from './Filter.styled';
+
+/**
+ * The Filter checkbox implemented for the "people" page where the user can search and filter
+ * for employees and employers.
+ */
+export default function Filter({ children, ...props }) {
+  return (
+    <Label>
+      {children}
+      <InputField type="checkbox" {...props}></InputField>
+    </Label>
+  );
+}
+
+Filter.defaultProps = {};

--- a/src/components/Form/Filter/Filter.styled.js
+++ b/src/components/Form/Filter/Filter.styled.js
@@ -1,0 +1,126 @@
+import styled from 'styled-components';
+
+export const Label = styled.label`
+  // --------------------------------------------
+  // BOX ----------------------------------------
+  padding: 10px 12px;
+
+  // --------------------------------------------
+  // FLEX ---------------------------------------
+  display: flex;
+  gap: 10px;
+  align-items: center;
+  justify-content: space-between;
+
+  // --------------------------------------------
+  // APPEARANCE ---------------------------------
+  border-radius: 12px;
+  border: 2px solid var(--colors-spindle);
+  background-color: transparent;
+  box-shadow: 0px 0px 0px 2px transparent;
+
+  // --------------------------------------------
+  // FONT ---------------------------------------
+  font-size: 0.875rem;
+  font-weight: 500;
+
+  // --------------------------------------------
+  // TRANSITIONS --------------------------------
+  transition: box-shadow 250ms ease, background-color 250ms ease;
+
+  // --------------------------------------------
+  // SIBLINGS -----------------------------------
+  & + & {
+    margin-left: 16px;
+  }
+
+  // --------------------------------------------
+  // PSEUDO CLASSES -----------------------------
+  &:hover,
+  &:active,
+  // :focus-within isn't compatible with Edge < 79
+  &:focus,
+  &:focus-within {
+    background-color: var(--colors-linkWater);
+  }
+  // :focus-within isn't compatible with Edge < 79
+  &:focus,
+  &:focus-within {
+    box-shadow: 0px 0px 0px 2px var(--colors-irisBlue);
+  }
+`;
+
+export const InputField = styled.input`
+  // --------------------------------------------
+  // RESET BROWSER STYLES -----------------------
+  -moz-appearance: none;
+  -webkit-appearance: none;
+  -o-appearance: none;
+
+  // --------------------------------------------
+  // BOX ----------------------------------------
+  // Ease centering the ::after pseudo element
+  box-sizing: content-box;
+
+  // --------------------------------------------
+  // DIMENSIONS ---------------------------------
+  min-width: 12px;
+  max-width: 12px;
+  height: 12px;
+
+  // --------------------------------------------
+  // FLEX ---------------------------------------
+  display: flex;
+  align-items: center;
+  justify-content: center;
+
+  // --------------------------------------------
+  // APPEARANCE ---------------------------------
+  border: 1px solid var(--colors-spindle);
+  border-radius: 2px;
+
+  // --------------------------------------------
+  // TRANSITIONS --------------------------------
+  transition: border-color 250ms ease;
+
+  // --------------------------------------------
+  // PSEUDO-ELEMENTS ----------------------------
+  &::after {
+    display: block;
+    position: relative;
+    content: '';
+
+    // --------------------------------------------
+    // DIMENSIONS ---------------------------------
+    width: 8px;
+    height: 8px;
+
+    // --------------------------------------------
+    // APPEARANCE ---------------------------------
+    transition: background-color 250ms ease;
+    background-color: transparent;
+    border-radius: 2px;
+  }
+
+  // --------------------------------------------
+  // CHECKED ------------------------------------
+  &:checked::after {
+    // --------------------------------------------
+    // APPEARANCE ---------------------------------
+    background-color: var(--colors-irisBlue);
+  }
+
+  // --------------------------------------------
+  // PSEUDO CLASSES -----------------------------
+  &:hover,
+  &:focus,
+  &:active {
+    border-color: var(--colors-irisBlue);
+  }
+
+  // :focus-within isn't compatible with Edge < 79
+  &:focus,
+  &:focus-within {
+    outline: none;
+  }
+`;

--- a/src/components/Form/Filter/Filter.test.jsx
+++ b/src/components/Form/Filter/Filter.test.jsx
@@ -1,0 +1,55 @@
+import userEvent from '@testing-library/user-event';
+import { render, screen } from '@testing-library/react';
+
+import Filter from './';
+
+describe('Filter', () => {
+  it('When rendered, should render correctly', () => {
+    // ARRANGE
+    render(<Filter>Foo</Filter>);
+
+    // ASSERT
+    expect(screen.getByLabelText('Foo')).toBeInTheDocument();
+  });
+
+  it('When passed some custom attributes, should spread them', () => {
+    // ARRANGE
+    render(<Filter data-foo="12">Foo</Filter>);
+    const filter = screen.getByLabelText('Foo');
+
+    // ASSERT
+    expect(filter.getAttribute('data-foo')).toBe('12');
+  });
+
+  it('When rendered as an uncontrolled component, should allow the users checking it', () => {
+    // ARRANGE
+    render(<Filter>Foo</Filter>);
+    const filter = screen.getByLabelText('Foo');
+
+    // ACT
+    userEvent.click(filter);
+
+    // ASSERT
+    expect(filter.checked).toEqual(true);
+  });
+
+  it('When rendered as a controlled component, should render the passed value and call the passed callback', () => {
+    // ARRANGE
+    const onChange = jest.fn();
+    render(
+      <Filter checked={true} onChange={onChange}>
+        Foo
+      </Filter>
+    );
+    const filter = screen.getByLabelText('Foo');
+
+    expect(filter.checked).toEqual(true);
+    expect(onChange).toHaveBeenCalledTimes(0);
+
+    // ACT
+    userEvent.click(filter);
+
+    // ASSERT
+    expect(onChange).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/components/Form/Filter/index.js
+++ b/src/components/Form/Filter/index.js
@@ -1,0 +1,1 @@
+export { default } from './Filter';

--- a/src/pages/Playground/Playground.js
+++ b/src/pages/Playground/Playground.js
@@ -2,16 +2,17 @@ import styled from 'styled-components';
 import { Link } from 'react-router-dom';
 
 import Button from 'components/Button';
+import Filter from 'components/Form/Filter';
 import LoadingLogo from 'components/LoadingLogo';
 import Text, { TextLight } from 'components/Text';
-import { Card, CardHeader, CardBody, CardFooter } from 'components/Card';
-import { Table, TableThCell, TableCell, TableRow } from 'components/Table';
 import TextField from 'components/Form/TextField';
 import SelectField from 'components/Form/SelectField';
 import SearchField from 'components/Form/SearchField';
+import { Card, CardHeader, CardBody, CardFooter } from 'components/Card';
+import { Table, TableThCell, TableCell, TableRow } from 'components/Table';
 
-import { ReactComponent as IconSearch } from 'theme/icons/search.svg';
 import { ReactComponent as IconUser } from 'theme/icons/user.svg';
+import { ReactComponent as IconSearch } from 'theme/icons/search.svg';
 import { ReactComponent as IconTimesCircle } from 'theme/icons/times-circle.svg';
 
 const Container = styled.main`
@@ -49,6 +50,11 @@ export default function Playground() {
       <TitleComponent>{`<SearchField>`}</TitleComponent>
       <Demo>
         <SearchField placeholder="Search employees..." />
+      </Demo>
+
+      <TitleComponent>{`<Filter>`}</TitleComponent>
+      <Demo>
+        <Filter>Employee</Filter>
       </Demo>
 
       <TitleComponent>{`<Text>`}</TitleComponent>

--- a/src/theme/colors.js
+++ b/src/theme/colors.js
@@ -10,6 +10,7 @@ const colors = css`
   --colors-lynch: #617798;
   --colors-pigeon: #a8bdd4;
   --colors-heather: #b1becd;
+  --colors-spindle: #b7b8eb;
   --colors-heather-rgb: 177, 190, 205;
 
   --colors-mischka: #e8ecee;


### PR DESCRIPTION
Before reviewing this PR, please review and discuss the `SearchField` one (#3) where there is a long description of my approach and some doubts, especially about the browsers to be supported. The same considerations are valid here, and this PR is rebased over the `SearchField` one (#3).

# Filter

This PR is meant to introduce the `Filter` component.

## Useful resources
- [Design specs](https://www.figma.com/file/ypsdDsJCUYq75YuwHl0tQ3/FE-code-exercise-NoriSte-clone?node-id=3329%3A1450)
- [My doubts about the Design Specs](#2) and, primarily, the browser to be supported.

## Look & Feel
Side by side, you can see the Design specs (left) and the implementation (right).

![128820303-8b2281a2-4115-4ec0-96c6-9c638f191bdb](https://user-images.githubusercontent.com/173663/136149327-35390ccd-606f-4db8-9c53-f9e6e2b2b641.jpg)


## Tests
Please take a look at the tests I wrote for the `SearchField` one (#3). The same considerations are valid here.

## Browser compatibility
I tested it on:
- Chrome 92
- Firefox Dev Edition 91
- Safari 14.1
- Edge 42 (see below for the issues)

Some features could need to be revisited if we decide to support older browsers (especially Edge 42):
- CSS Flex `gap` ([compatibility](https://caniuse.com/flexbox-gap)): not supported on Edge < 79
- CSS `focus-within` pseudo class: ([compatibility](https://caniuse.com/?search=focus-within)): not supported on Edge < 79
