### PR TITLE
feat(components): Add Link component

### DIFF
--- a/src/components/Link/Link.jsx
+++ b/src/components/Link/Link.jsx
@@ -1,0 +1,5 @@
+import { LinkStyled } from './Link.styled';
+
+export default function Link({ children, ...props }) {
+  return <LinkStyled {...props}>{children}</LinkStyled>;
+}

--- a/src/components/Link/Link.styled.js
+++ b/src/components/Link/Link.styled.js
@@ -1,0 +1,19 @@
+import styled from 'styled-components';
+
+export const LinkStyled = styled.a`
+  // --------------------------------------------
+  // APPEARANCE ---------------------------------
+  color: var(--colors-irisBlue);
+  outline: none;
+  text-decoration: none;
+
+  // --------------------------------------------
+  // INTERACTION --------------------------------
+  cursor: pointer;
+
+  // --------------------------------------------
+  // PSEUDO CLASSES -----------------------------
+  &:hover {
+    text-decoration: underline rgba(var(--colors-irisBlue-rgb), 0.45);
+  }
+`;

--- a/src/components/Link/Link.test.jsx
+++ b/src/components/Link/Link.test.jsx
@@ -1,0 +1,28 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import Link from './';
+
+describe('Link', () => {
+  it('renders correctly', () => {
+    render(<Link>Hello</Link>);
+
+    const link = screen.getByText('Hello');
+
+    expect(link).toHaveTextContent('Hello');
+  });
+
+  it('spreads custom attributes', () => {
+    const clickFn = jest.fn();
+    render(
+      <Link data-foo="12" onClick={clickFn}>
+        Hello
+      </Link>
+    );
+
+    const link = screen.getByText('Hello');
+
+    expect(link.getAttribute('data-foo')).toBe('12');
+
+    fireEvent.click(link);
+    expect(clickFn).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/components/Link/index.js
+++ b/src/components/Link/index.js
@@ -1,0 +1,1 @@
+export { default } from './Link';

--- a/src/pages/Playground/Playground.js
+++ b/src/pages/Playground/Playground.js
@@ -1,6 +1,7 @@
 import styled from 'styled-components';
-import { Link } from 'react-router-dom';
+import { Link as RouterLink } from 'react-router-dom';
 
+import Link from 'components/Link';
 import Button from 'components/Button';
 import Filter from 'components/Form/Filter';
 import LoadingLogo from 'components/LoadingLogo';
@@ -45,7 +46,7 @@ export default function Playground() {
         These are some of the base components already built for you. You can{' '}
         <Text size="bodyBold">use and modify</Text> them as you need!
       </TextLight>
-      <Link to="/">Go Home</Link>
+      <RouterLink to="/">Go Home</RouterLink>
 
       <TitleComponent>{`<SearchField>`}</TitleComponent>
       <Demo>
@@ -72,6 +73,11 @@ export default function Playground() {
       <TitleComponent>{`<Button white>`}</TitleComponent>
       <Demo>
         <Button white>Continue</Button>
+      </Demo>
+
+      <TitleComponent>{`<Link>`}</TitleComponent>
+      <Demo>
+        <Link>Continue</Link>
       </Demo>
 
       <TitleComponent>{`<Card>`}</TitleComponent>

--- a/src/theme/colors.js
+++ b/src/theme/colors.js
@@ -2,6 +2,7 @@ import { css } from 'styled-components';
 
 const colors = css`
   --colors-irisBlue: #624de3;
+  --colors-irisBlue-rgb: 98, 77, 227;
   --colors-darkBlue: #00234b;
   --colors-redPink: #ff4a5a;
   --colors-cosmos: #ffdbde;
@@ -10,8 +11,8 @@ const colors = css`
   --colors-lynch: #617798;
   --colors-pigeon: #a8bdd4;
   --colors-heather: #b1becd;
-  --colors-spindle: #b7b8eb;
   --colors-heather-rgb: 177, 190, 205;
+  --colors-spindle: #b7b8eb;
 
   --colors-mischka: #e8ecee;
   --colors-catskillWhite: #eaf0f6;


### PR DESCRIPTION
# Link

This PR is meant to add the Link component.

## Look & Feel
The [Design specs](https://www.figma.com/file/ypsdDsJCUYq75YuwHl0tQ3/FE-code-exercise-NoriSte-clone?node-id=0%3A1) don't provide the specs for the link but, in the [People](https://www.figma.com/file/ypsdDsJCUYq75YuwHl0tQ3/FE-code-exercise-NoriSte-clone?node-id=3329%3A1281) specs, the link has "Iris blue" color. That's why I'm introducing this Link component, with the minimum style required, brought half from the People List and half from remote.com, after looking at how the site styles the links.

![131089046-8e8fcb9d-d2f5-4a5e-873d-1b30aa2be348](https://user-images.githubusercontent.com/173663/136149847-092229d9-5b83-4e8e-931a-74055ac094a0.jpg)

## Theme
I introduce the `--colors-irisBlue-rgb` variable.

## Tests
The component is almost a copy of `Button`. I copied the tests too.