### PR TITLE
feat(domain): Add the domain types and the fetchPeople service

### DIFF
--- a/src/pages/People/services/fetchPeople/fetchPeople.js
+++ b/src/pages/People/services/fetchPeople/fetchPeople.js
@@ -1,0 +1,45 @@
+// @ts-check
+
+/** @typedef {import('../../types.js').People} People */
+/** @typedef {import('../../types.js').Filter} Filter */
+/** @typedef {import('../../types.js').FetchError} FetchError */
+
+import { getQueryString } from './utils/getQueryString';
+import { normalizePeople } from './utils/normalizePeople';
+
+/**
+ * Fetch the People list.
+ *
+ * @param {Filter} filter
+ */
+export function fetchPeople(filter) {
+  if (filter.employment.length === 0) return getEmptyEmploymentError();
+
+  const url = `http://localhost:4002/people${getQueryString(filter.employment, filter.query)}`;
+  const controller = new AbortController();
+
+  /** @type {Promise<People[]>} */
+  const load = fetch(url, { signal: controller.signal })
+    .then((response) => response.json())
+    .then((response) => normalizePeople(response));
+
+  /** @type {() => void} */
+  const cancel = () => controller.abort();
+
+  return { load, cancel };
+}
+
+/**
+ * Create a standard error for the no-employment parameters.
+ */
+function getEmptyEmploymentError() {
+  /** @type {Promise<[]>} */
+  const load = Promise.resolve([]);
+  /** @type {() => void} */
+  const cancel = () => {};
+
+  return {
+    load,
+    cancel,
+  };
+}

--- a/src/pages/People/services/fetchPeople/index.js
+++ b/src/pages/People/services/fetchPeople/index.js
@@ -1,0 +1,1 @@
+export * from './fetchPeople';

--- a/src/pages/People/services/fetchPeople/utils/getQueryString.js
+++ b/src/pages/People/services/fetchPeople/utils/getQueryString.js
@@ -1,0 +1,22 @@
+// @ts-check
+
+/** @typedef {import('../../../types.js').Employment} Employment */
+
+/**
+ * Create querystring for the given search parameters.
+ *
+ * @param {Employment[]} employment - Employment type
+ * @param {string} query - Free text search
+ */
+export function getQueryString(employment, query) {
+  const params = [];
+
+  if (query) params.push(`name_like=${query}`);
+
+  // If the user is looking for both employees and contractor, no `employment` param must be set
+  if (employment.length === 1) params.push(`employment=${employment}`);
+
+  if (params.length === 0) return '';
+
+  return '?' + params.join('&');
+}

--- a/src/pages/People/services/fetchPeople/utils/normalizePeople.js
+++ b/src/pages/People/services/fetchPeople/utils/normalizePeople.js
@@ -1,0 +1,41 @@
+// @ts-check
+
+/** @typedef {import('../../../types.js').People} People */
+
+/**
+ * Normalize/check the server response.
+ *
+ * @param {any} response
+ * @returns {People[]}
+ */
+export function normalizePeople(response) {
+  for (const people of response) {
+    if (!isPeople(people)) {
+      throw new Error("The object isn't a valid People");
+    }
+  }
+
+  return response;
+}
+
+/**
+ * Check if given object is a valid People.
+ *
+ * @param {any} people
+ * @returns {people is People}
+ */
+function isPeople(people) {
+  /** @type {People} */
+  const p = people;
+
+  if (typeof p.id !== 'number') return false;
+  if (typeof p.name !== 'string') return false;
+  if (typeof p.salary !== 'number') return false;
+  if (typeof p.country !== 'string') return false;
+  if (typeof p.jobTitle !== 'string') return false;
+  if (typeof p.currency !== 'string') return false;
+
+  if (p.employment !== 'employee' && p.employment !== 'contractor') return false;
+
+  return true;
+}

--- a/src/pages/People/services/index.js
+++ b/src/pages/People/services/index.js
@@ -1,0 +1,1 @@
+export * from './fetchPeople';

--- a/src/pages/People/types.js
+++ b/src/pages/People/types.js
@@ -1,0 +1,41 @@
+// @ts-check
+
+// ---------------------------------------------------------------
+// DOMAIN
+
+/**
+ * @typedef {Object} People
+ * @property {number} id
+ * @property {string} name
+ * @property {number} salary
+ * @property {string} country
+ * @property {string} jobTitle
+ * @property {Currency} currency
+ * @property {Employment} employment
+ *
+ * @typedef {'employee' | 'contractor'} Employment
+ *
+ * @typedef {'EUR' | 'USD' | 'GBP'} Currency
+ */
+
+// ---------------------------------------------------------------
+// APP
+
+/**
+ * @typedef {Object} Filter
+ * @property {string} query
+ * @property {Employment[]} employment
+ */
+
+/**
+ * @typedef {Object} FetchError
+ * @property {string} errorMessage
+ */
+
+/**
+ * @typedef {Object} FetchResponse
+ * @property {People[]} people
+ */
+
+// Get rid of JSDoc "file is not a module" error
+export const noop = {};


### PR DESCRIPTION
# Domain types

With the `src/pages/people/types.js`, I'd like to introduce the JSDoc-related types, to get auto-completion and IDE errors during the development phase. This is a harmless introduction of types. My tool of choice is TypeScript but I don't introduce it without a prior discussion with the team. Meanwhile, if you want to look at some principles, I respect when writing TypeScript, I recently [published an internal coding style document](https://dev.to/noriste/routemanager-ui-coding-patterns-typescript-42hb) of ours.

# Fetch People service

Along with the domain types, I've added the `fetchPeople` service that allows:
- to fetch the people
- to cancel the previous fetch. This is extremely important since the design specs report that "The search is made on value change." even if I suggested choosing a debounce strategy in #2 
- to validate the server data

Please note: through JSDoc, I apply the same opinionated best practices I use with TypeScript: [type inference](https://dev.to/noriste/routemanager-ui-coding-patterns-typescript-42hb#take-advantage-of-types-inference-as-much-as-possible). That's why I didn't document the `@returns` type.

## Browser compatibility
I don't think supporting IE11 is a thing, but please check #2 and my concerns related to browser compatibility. In the `fetchPeople` service, I use the `AbortController` API, [not compatible with IE11](https://caniuse.com/abortcontroller).