### PR TITLE
feat(app): Add the people machine

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,13 +3,15 @@
   "version": "0.1.0",
   "private": true,
   "dependencies": {
+    "@xstate/react": "1.5.1",
     "react": "^17.0.1",
     "react-dom": "^17.0.1",
     "react-router-dom": "^5.2.0",
     "react-scripts": "4.0.1",
     "styled-components": "^5.2.1",
     "styled-normalize": "^8.0.7",
-    "web-vitals": "^0.2.4"
+    "web-vitals": "^0.2.4",
+    "xstate": "4.22.0"
   },
   "engines": {
     "node": ">=15.10.x",

--- a/src/pages/People/machine/MachineRoot.jsx
+++ b/src/pages/People/machine/MachineRoot.jsx
@@ -1,0 +1,36 @@
+// @ts-check
+
+/** @typedef {import('react')} React */
+/** @typedef {import('./types.js').Events} Events */
+/** @typedef {import('./types.js').States} States */
+/** @typedef {import('./types.js').Context} Context */
+
+import { createContext, useContext } from 'react';
+import { useInterpret } from '@xstate/react';
+import { machine } from './machine';
+
+/** @type React.Context<import('xstate').Interpreter<Context, any, Events, States> | undefined> */
+const MachineContext = createContext(undefined);
+
+/**
+ * The machine is exposed to all the children of `MachineRoot`
+ *
+ * @param {{ children: JSX.Element}} [Props]
+ */
+export function MachineRoot({ children }) {
+  const service = useInterpret(machine, { devTools: process.env.NODE_ENV === 'development' });
+
+  return <MachineContext.Provider value={service}>{children}</MachineContext.Provider>;
+}
+
+/**
+ * Used by every component that needs to access the running machine. It hides the React Context,
+ * easing future refactors.
+ */
+export function useMachine() {
+  const service = useContext(MachineContext);
+  if (!service) {
+    throw new Error('Missing MachineRoot');
+  }
+  return service;
+}

--- a/src/pages/People/machine/index.js
+++ b/src/pages/People/machine/index.js
@@ -1,0 +1,1 @@
+export * from './MachineRoot';

--- a/src/pages/People/machine/machine.js
+++ b/src/pages/People/machine/machine.js
@@ -1,0 +1,149 @@
+// @ts-check
+
+/** @typedef {import('./types.js').Events} Events */
+/** @typedef {import('./types.js').States} States */
+/** @typedef {import('./types.js').Context} Context */
+/** @typedef {import('./types.js').InitialContext} InitialContext */
+/** @typedef {import('./types.js').SetFilterEvent} SetFilterEvent */
+
+import { assign, createMachine } from 'xstate';
+import { fetchPeople } from '../services';
+
+/** @type {Context} */
+export const initialContext = {
+  people: [],
+  filter: {
+    query: '',
+    employment: ['employee', 'contractor'],
+  },
+  debounceFilter: undefined,
+  fetchErrors: [],
+  fetching: false,
+};
+
+/** @type {import('xstate').StateMachine<Context, any, Events, States>} */
+export const machine = createMachine(
+  {
+    id: 'people',
+    strict: true,
+    initial: 'idle',
+    context: initialContext,
+    states: {
+      // INITIAL STATE
+      // The machine start still, allowing external control over the first fetch
+      idle: { on: { START: 'fetch' } },
+
+      // FETCH STATES
+      debounceFetch: {
+        on: {
+          // Changing the filters reset the debounce
+          SET_FILTER: { actions: 'setFilter', target: 'debounceFetch' },
+        },
+        after: {
+          debounceDelay: {
+            target: 'fetch',
+            actions: ['swapNextFilter'],
+          },
+        },
+      },
+      fetch: {
+        on: {
+          // Changing the filters reset the debounce and cancel the previous fetch, if any
+          SET_FILTER: { actions: 'setFilter', target: 'debounceFetch' },
+
+          // Fetch completion management
+          SUCCESS: { actions: 'setSuccessData', target: 'success' },
+          FAILURE: { actions: 'setErrorData', target: 'failure' },
+        },
+        entry: 'setFetchingData',
+        invoke: { src: 'fetchPeople' },
+      },
+
+      // SUCCESS STATE
+      success: {
+        on: {
+          // Changing the filters start the debounced fetch
+          SET_FILTER: { actions: 'setFilter', target: 'debounceFetch' },
+        },
+      },
+
+      // ERROR STATE
+      failure: {
+        on: {
+          // After a failure, retying with the same filter happens immediately
+          RETRY: { target: 'fetch' },
+
+          // Changing the filters start the debounced fetch
+          SET_FILTER: { actions: 'setFilter', target: 'debounceFetch' },
+        },
+      },
+    },
+  },
+
+  {
+    services: {
+      // Fetch the new people and return a cancellation method, useful for subsequent, debounced, fetches
+      fetchPeople: (context) => (send) => {
+        const { load, cancel } = fetchPeople(context.filter);
+        load
+          .then((people) => send({ type: 'SUCCESS', people }))
+          .catch((error) =>
+            send({
+              type: 'FAILURE',
+              error: !!error.errorMessage
+                ? { errorMessage: error.errorMessage }
+                : { errorMessage: error.stack },
+            })
+          );
+        return cancel;
+      },
+    },
+
+    actions: {
+      // Reset the previous fetch data and store the last fetched data
+      setSuccessData: assign({
+        people: (_ctx, event) => (event.type === 'SUCCESS' ? event.people : []),
+        fetchErrors: (_ctx) => [],
+        fetching: (_ctx) => false,
+      }),
+
+      // Reset the previous fetch data and piles up the received error
+      setErrorData: assign({
+        people: (_ctx) => [],
+        fetchErrors: (ctx, event) => [
+          ...ctx.fetchErrors,
+          ...(event.type === 'FAILURE' ? [event.error] : []),
+        ],
+        fetching: (_ctx) => false,
+      }),
+
+      // Store that the machine is fetching
+      setFetchingData: assign({
+        fetching: (_ctx) => true,
+      }),
+
+      // Change the filter of the next fetch
+      setFilter: assign({
+        debounceFilter: (_ctx, event) => {
+          if (event.type !== 'SET_FILTER') throw new Error(`Unmanaged ${event.type} event`);
+
+          return event.filter;
+        },
+      }),
+
+      // Empty the debounced filter and set the one to be used for fetching the new data
+      swapNextFilter: assign({
+        filter: (ctx) => {
+          if (!ctx.debounceFilter) throw new Error('Missing ctx.debounceFilter');
+
+          return ctx.debounceFilter;
+        },
+        debounceFilter: (_ctx) => undefined,
+      }),
+    },
+
+    delays: {
+      debounceDelay: 0,
+    },
+  }
+);

--- a/src/pages/People/machine/machine.test.js
+++ b/src/pages/People/machine/machine.test.js
@@ -1,0 +1,240 @@
+/** @typedef {import('../types').People} People */
+/** @typedef {import('../types').FetchError} FetchError */
+
+import { interpret } from 'xstate';
+import { machine, initialContext } from './machine';
+
+// ----------------------------------------------
+// MOCK DATA ------------------------------------
+/** @type {People} */
+const annHenry = {
+  id: 1,
+  name: 'Ann Henry',
+  jobTitle: 'Product manager',
+  country: 'Germany',
+  salary: 120000,
+  currency: 'EUR',
+  employment: 'employee',
+};
+
+/** @type {People} */
+const vittoriaJanson = {
+  id: 2,
+  name: 'Vittoria Janson',
+  jobTitle: 'Pianist',
+  country: 'Italy',
+  salary: 70000,
+  currency: 'EUR',
+  employment: 'contractor',
+};
+
+const error = { errorMessage: 'Failure' };
+
+/** @type {People[]} */
+const defaultFetchData = [{ ...annHenry }, { ...vittoriaJanson }];
+
+// --------------------------------------------
+// TESTING UTILS ------------------------------
+// A generic `wait` utility
+function awaitTimeout(timeout) {
+  return new Promise((resolve) => {
+    setTimeout(resolve, timeout);
+  });
+}
+
+/**
+ * Allow programmatically control the external events that impact the machine.
+ * In particular: `resolveFetchMock` and `rejectFetchMock` allow controlling the behavior
+ * of the mocked external service that fetches the people.
+ *
+ * @param {number} [debounceDelay=1]
+ */
+function createMockedMachine(debounceDelay = 1) {
+  const fetchMock = jest.fn(() => () => {
+    // see resolveFetchMock and rejectFetchMock
+  });
+
+  const machineMock = machine.withConfig({
+    services: { fetchPeople: fetchMock },
+    // speed up the delay of the machine' debounce
+    delays: { DEBOUNCE_DELAY: () => debounceDelay },
+  });
+
+  const service = interpret(machineMock).start();
+
+  /** @type {(people:People[]) => void} */
+  const resolveFetchMock = (people) => {
+    service.send({ type: 'SUCCESS', people });
+  };
+  /** @type {(error: FetchError) => void} */
+  const rejectFetchMock = (error) => {
+    service.send({ type: 'FAILURE', error });
+  };
+
+  const waitDebouncedFetch = () => awaitTimeout(debounceDelay);
+
+  return {
+    service,
+    fetchMock,
+    machineMock,
+    rejectFetchMock,
+    resolveFetchMock,
+    waitDebouncedFetch,
+  };
+}
+
+// --------------------------------------------
+// TESTS --------------------------------------
+describe('People machine', () => {
+  describe('Initial state', () => {
+    it('When created, should do nothing', () => {
+      // ARRANGE
+      const { service, fetchMock } = createMockedMachine();
+
+      // ASSERT
+      expect(service.state).toMatchObject({
+        value: 'idle',
+        context: initialContext,
+      });
+      expect(fetchMock).toHaveBeenCalledTimes(0);
+    });
+
+    it('When started, should fetch the data', () => {
+      // ARRANGE
+      const { service, fetchMock } = createMockedMachine();
+
+      // ACT
+      service.send({ type: 'START' });
+
+      // ASSERT
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+      expect(service.state).toMatchObject({ value: 'fetch', context: { fetching: true } });
+    });
+  });
+
+  describe('First fetch', () => {
+    it('When the fetch resolves, should store the data', () => {
+      // ARRANGE
+      const { service, resolveFetchMock } = createMockedMachine();
+
+      // ACT
+      service.send({ type: 'START' });
+      resolveFetchMock(defaultFetchData);
+
+      // ASSERT
+      expect(service.state).toMatchObject({
+        value: 'success',
+        context: { people: defaultFetchData, fetching: false },
+      });
+    });
+
+    it('When the fetch rejects, should store the error', () => {
+      // ARRANGE
+      const { service, rejectFetchMock } = createMockedMachine();
+
+      // ACT
+      service.send({ type: 'START' });
+      rejectFetchMock(error);
+
+      // ASSERT
+      expect(service.state).toMatchObject({
+        value: 'failure',
+        context: { fetching: false, fetchErrors: [error] },
+      });
+    });
+
+    it('When the fetch rejects twice, should store all the errors', () => {
+      // ARRANGE
+      const { service, rejectFetchMock } = createMockedMachine();
+
+      // ACT
+      service.send({ type: 'START' });
+      rejectFetchMock(error);
+      service.send({ type: 'RETRY' });
+      rejectFetchMock(error);
+
+      // ASSERT
+      expect(service.state).toMatchObject({
+        value: 'failure',
+        context: { fetching: false, fetchErrors: [error, error] },
+      });
+    });
+  });
+
+  describe('Querying', () => {
+    it('When the query is set, should debounce the next fetch', async () => {
+      // ARRANGE
+      const { service, fetchMock, resolveFetchMock, waitDebouncedFetch } = createMockedMachine(1);
+
+      // ACT
+      service.send({ type: 'START' });
+      resolveFetchMock(defaultFetchData);
+      service.send({
+        type: 'SET_FILTER',
+        filter: { ...service.state.context.filter, query: 'Ann Henry' },
+      });
+
+      // ASSERT
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+      await waitDebouncedFetch();
+      expect(fetchMock).toHaveBeenCalledTimes(2);
+    });
+
+    it('When the query is set, should pass the query to the next fetch', async () => {
+      // ARRANGE
+      const query = 'Ann Henry';
+      const filteredFetchData = [annHenry];
+      const { service, fetchMock, resolveFetchMock, waitDebouncedFetch } = createMockedMachine(1);
+
+      // ACT
+      service.send({ type: 'START' });
+      resolveFetchMock(defaultFetchData);
+      service.send({ type: 'SET_FILTER', filter: { ...service.state.context.filter, query } });
+      await waitDebouncedFetch();
+      resolveFetchMock(filteredFetchData);
+
+      // ASSERT
+      expect(fetchMock).toHaveBeenLastCalledWith(
+        // machine' context
+        expect.objectContaining({ filter: expect.objectContaining({ query }) }),
+        // machine' states and invokeMeta, useless for the purpose of the tests
+        expect.anything(),
+        expect.anything()
+      );
+      expect(service.state).toMatchObject({
+        value: 'success',
+        context: { people: filteredFetchData, fetching: false },
+      });
+    });
+
+    it('When retrying, should retry with the last query', async () => {
+      // ARRANGE
+      const query = 'Ann Henry';
+      const {
+        service,
+        fetchMock,
+        rejectFetchMock,
+        resolveFetchMock,
+        waitDebouncedFetch,
+      } = createMockedMachine(1);
+
+      // ACT
+      service.send({ type: 'START' });
+      resolveFetchMock(defaultFetchData);
+      service.send({ type: 'SET_FILTER', filter: { ...service.state.context.filter, query } });
+      await waitDebouncedFetch();
+      rejectFetchMock(error);
+      service.send({ type: 'RETRY' });
+      await waitDebouncedFetch();
+
+      // ASSERT
+      expect(fetchMock).toHaveBeenLastCalledWith(
+        // machine' context
+        expect.objectContaining({ filter: expect.objectContaining({ query }) }),
+        // machine' states and invokeMeta, useless for the purpose of the tests
+        expect.anything(),
+        expect.anything()
+      );
+    });
+  });
+});

--- a/src/pages/People/machine/types.js
+++ b/src/pages/People/machine/types.js
@@ -1,0 +1,134 @@
+// @ts-check
+
+/** @typedef {import('../types.js').Filter} Filter */
+/** @typedef {import('../types.js').People} People */
+/** @typedef {import('../types.js').Employment} Employment */
+/** @typedef {import('../types.js').FetchError} FetchError */
+
+// ---------------------------------------------------------------
+// CONTEXT
+/**
+ * @typedef {Object} Context
+ * @property {Filter} filter The filter used for the last fetch
+ * @property {Filter | undefined} debounceFilter The filter of the next, debounced, fetch if any
+ * @property {[] | People[]} people The data returned from the last fetch
+ * @property {[] | FetchError[]} fetchErrors The queue of errors of the last fetches, emptied when the latest fetch succeeded
+ * @property {boolean} fetching If the machine is fetching or not
+ *
+ *
+ * Initially, the state machine doesn't contain any data bu the default filter.
+ * @typedef {Object} InitialContext
+ * @property {Filter} filter
+ * @property {undefined} debounceFilter
+ * @property {false} fetching
+ * @property {[]} people
+ * @property {[]} fetchErrors
+ *
+ *
+ * When the next fetch is debounced, the next filter is stored in `debounceFilter`
+ * @typedef {Object} DebounceFetchContext
+ * @property {Filter} debounceFilter
+ *
+ *
+ * During the fetch, the context includes the `filter` passed to the server and a `fetching` indicator.
+ * @typedef {Object} FetchContext
+ * @property {Filter} filter
+ * @property {true} fetching
+ *
+ *
+ * When the fetch succeed, the data are stored and the errors reset.
+ * @typedef {Object} SuccessContext
+ * @property {People[]} people
+ * @property {Filter} filter
+ * @property {[]} fetchErrors
+ * @property {false} fetching
+ *
+ *
+ * In case of errors, the data are reset and the list of the last errors are stored.
+ * @typedef {Object} FailureContext
+ * @property {[]} people
+ * @property {Filter} filter
+ * @property {FetchError[]} fetchErrors
+ * @property {false} fetching
+ *
+ */
+
+// ---------------------------------------------------------------
+// EVENTS
+/**
+ * @typedef {InternalEvents | ExternalEvents | UserEvents} Events
+ */
+
+// INTERNAL EVENTS
+/**
+ * Internal events, helpful for typing purposes.
+ * @typedef {InternalFetchSuccessEvent | InternalFetchFailureEvent} InternalEvents
+ *
+ *
+ * @typedef {Object} InternalFetchSuccessEvent
+ * @property {'SUCCESS'} type
+ * @property {People[]} people
+ *
+ *
+ * @typedef {Object} InternalFetchFailureEvent
+ * @property {'FAILURE'} type
+ * @property {FetchError} error
+ *
+ */
+
+// EXTERNAL EVENTS
+/**
+ * All the events triggered by the consumer but not necessarily directly by the user.
+ * @typedef {StartEvent} ExternalEvents
+ *
+ *
+ * @typedef {Object} StartEvent
+ * @property {'START'} type
+ *
+ */
+
+// USER EVENTS
+/**
+ * All the events triggered mostly by user inputs.
+ * @typedef {RetryEvent | SetFilterEvent} UserEvents
+ *
+ *
+ * @typedef {Object} RetryEvent
+ * @property {'RETRY'} type
+ *
+ *
+ * @typedef {Object} SetFilterEvent
+ * @property {'SET_FILTER'} type
+ * @property {Filter} filter
+ */
+
+// ---------------------------------------------------------------
+// STATES
+/**
+ * All the possible states of the machine.
+ * @typedef {InitialState | FetchState | DebounceFetchState | SuccessState | FailureState} States
+ *
+ *
+ * @typedef {Object} InitialState
+ * @property {'idle'} value
+ * @property {Context & InitialContext} context
+ *
+ * @typedef {Object} FetchState
+ * @property {'fetch'} value
+ * @property {Context & FetchContext} context
+ *
+ * @typedef {Object} DebounceFetchState
+ * @property {'debounceFetch'} value
+ * @property {Context & DebounceFetchContext} context
+ *
+ * @typedef {Object} SuccessState
+ * @property {'success'} value
+ * @property {Context & SuccessContext} context
+ *
+ * @typedef {Object} FailureState
+ * @property {'failure'} value
+ * @property {Context & FailureContext} context
+ */
+
+// Get rid of JSDoc "file is not a module" error
+export const noop = {};


### PR DESCRIPTION
# People Finite State Machine

<img width="1921" alt="fsm-dark" src="https://user-images.githubusercontent.com/173663/132811145-e59e385e-7858-40db-b90f-af3e92f5f9ae.png">


## Design decisions
First of all, why **XState**: even if I'm not an XState expert yet, I chose it because I think it's a superior tool to manage, read, and document Finite State Machines, compared to reading "long" `useReducer` code or jumping through React hooks trying to understand what every `useEffect` does. I think that's  [David Khourshid's "Redux is half of a pattern"](https://dev.to/davidkpiano/redux-is-half-of-a-pattern-1-2-1hd7) is good reading for this topic. I got inspired by this article and by my willingness to gain experience with XState, to understand if I/we like the development pattern XState introduces carefully. Please note that we recently started using it at work, and I'm currently driving an XState Working Group.


### Machine

The design patterns used in the code of the Finite State Machine are:

- **the machine' initial state is `idle`**: initially, the People must be fetched to fill the list, and it will happen when the People page mount. Anyway, moving the machine from its initial "idle" state to fetching the People is a controlled event that must be sent by the People page itself, avoiding the machine to deliberately start fetching in a moment the app doesn't expect it to do.

```js
export const machine = createMachine(
  {
    initial: 'idle',
    // ...
  }
```

- **the events are uppercased**: more, events are the only entity with an upper-cased name, to distinguish them from the rest of the entities.

- **preferring readability over smartness for transitions**: the `SET_FILTER`-related transitions are repeated for many states (less than five times, though). This is my choice, preferring the reader to immediately understand the managed events for each state, instead of jumping around the code because of an unnecessary abstraction.

- **avoiding inline callbacks and services**: callbacks and services can be invoked inline or moved to the machine's configuration object (the second `createMachine` parameter). This is primarily important for testing purposes, allowing the tests to override the configuration through the `machine.withConfig` function, instead of mocking the imported services (`fetchPeople`, in this case).

```js
export const machine = createMachine(
  { /* ... */ },
  {
    services: { // <-- NOTE: Services goe here
      // ...
    },
  }
);
```

- **avoiding inline delays**: the previous point is valid for the debounce delay too, if in the future the machine's delay changes, nothing changes for the tests, which override the debounce delay.

```js
export const machine = createMachine(
  { /* ... */ },
  {
    delays: { // <-- NOTE: Delays goe here
      // ...
    },
  }
);
```

### Types

The design patterns used for the Finite State Machine' types are:

- **every context includes only its specific overrides**: the machine' context always has all the properties, but the various `InitialContext`, `DebounceFetchContext`, etc. types specify only their specific content. They're not meant to be used isolated, but always through a `Context & InitialContext`-like intersection.

```js
/**
 * @typedef {Object} Context
 * @property {Filter} filter
 * @property {Filter | undefined} debounceFilter
 * @property {[] | People[]} people
 * @property {[] | FetchError[]} fetchErrors
 * @property {boolean} fetching
 *
 *
 * @typedef {Object} DebounceFetchContext // <-- NOTE: Specify only the properties to override
 * @property {Filter} debounceFilter
 *
 * // ...
 * // ...
 * // ...
 *
 * @typedef {Object} DebounceFetchState
 * @property {'debounceFetch'} value
 * @property {Context & DebounceFetchContext} context // <-- NOTE: the `Context & DebounceFetchContext` type
 */
```

- **event categories**: in the `types` module, the events are categorized based on
  - the internal events, especially the ones that bring data
  - the external events triggered directly by the user
  - the external events not triggered directly by the user (ex. the `START` event that moves the machine away from its idle state)

This allows the reader to immediately get an idea of what are the events thought for

```js
// ---------------------------------------------------------------
// EVENTS
/**
 * @typedef {InternalEvents | ExternalEvents | UserEvents} Events
 */
```


### Tests

The design patterns used for the tests of the Finite State Machine are:

- **strong readability**: I care a lot about tests' readability because they're the tools used to understand how the code works, and they must have a complexity level 10x lower than the code under test. The topic is quite subjective, obviously, but I tried my best to ease the future developers that
  - want to understand what the machine does to refactor it
  - need to fix the tests that are unexpectedly failing

The latter case is the most problematic. Usually, I tried to get the tests as clear as possible to ease the work of the fixing-tests developer that needs an immediate idea of how the tests work to fix them as fast as possible.

- **local mock data**: this point is strictly related to the "readability" one. I think that if the mock data are simple, they must stay in the same file to avoid external dependencies (take a look at `defaultFetchData` in `machine.test.js`).

- **linear testing flow and internal events**: the [Testing services chapter of the Testing Machines docs](https://xstate.js.org/docs/guides/testing.html#testing-services) pushes the developer to test a service-based machine like the following
```js
it('should eventually reach "success"', (done) => {
  const service = interpret(machine).onTransition((state) => {
    if (state.matches('success')) {
      done(); // <-- NOTE: asserting/succeeding first
    }
  });

  service.start();
  service.send({ type: 'SUCESSS', people: [/*...*/] }); // <-- NOTE: acting last
});
```

but:
- this worsen the readability because commonly, the tests have the assertion/success as the last step
- at the same time, the `{ type: 'SUCESSS', people: [/*...*/] })` is an internal event that no one must know, not even the machine' tests, because it's an implementation detail

To satisfy the above points, I prefer a test that looks like
```js
// ARRANGE
const { service, resolveFetchMock } = createMockedMachine();

// ACT
// NOTE: it's an external event, it's fine expliciting it
service.send({ type: 'START' });
// NOTE: exxternal services are managed through dedicated utilities, allow concentrating on the `data`
// the service should return
resolveFetchMock(defaultFetchData);

// ASSERT
expect(service.state).toMatchObject({
  value: 'success',
  context: { people: defaultFetchData, fetching: false },
});
```

- **`createMockedMachine utility`**: I first written all the tests, then carefully analyzed which code was common for all the tests that worsened their readability. The `createMockedMachine` utility creates a minimal configured machine but returns some utilities that allow controlling the fake `fetchPeople` service.

- **clear testing blocks**: every test, short or long, have clear `ARRANGE/ACT/ASSERT` blocks

- **test approach**: to test this machine, there are three main kinds of approaches
  1. a **functional test**-like approach: a user flow is performed, there isn't a clear "end" of the test, multiple-input combinations are tried in the same test
  2. a **single-flow** approach: every test contains multiple steps but is oriented to a single, clear, final result
  3. a **single-transition** approach: the machine starts in a specific state, an event is sent, the next state is checked out

  I opted for the second approach because:
  - the first approach leads too much to create a clone of the functional, browser-based, tests
  - the first approach generates very long tests, hard to follow without a "visual" counterpart
  - the third approach is too much oriented to test the machine' implementation details
  - the third approach needs the developer to know the XState' internal events

Test examples

<details>
  <summary>First approach example</summary>

```js
it('When the fetch fails, should allow retrying with the same filter and clear the errors', async () => {
  // ARRANGE
  const debounceDelay = 1
  const query = 'Ann Henry'
  const filteredFetchData = [annHenry]
  const {
    service,
    fetchMock,
    rejectFetchMock,
    resolveFetchMock,
    waitDebouncedFetch,
  } = createMockedMachine(debounceDelay)

  // 1. START THE MACHINE
  service.send({ type: 'START' })
  expect(fetchMock).toHaveBeenCalledTimes(1)

  // 2. REJECT THE FETCH
  rejectFetchMock(error)
  expect(service.state).toMatchObject({
    value: 'failure',
    context: { fetchErrors: [error] },
  })

  // 3. CHANGE THE QUERY
  service.send({ type: 'SET_QUERY', query })

  // 4. DEBOUNCED FETCH
  await waitDebouncedFetch()

  // 5. REJECT THE FETCH
  rejectFetchMock(error)
  expect(service.state).toMatchObject({ context: { fetchErrors: [error, error] } })
  expect(fetchMock).toHaveBeenCalledTimes(2)

  // 6. RETRY FETCHING
  service.send({ type: 'RETRY' })

  // 7. RESOLVE THE FETCH
  resolveFetchMock(filteredFetchData)
  expect(service.state).toMatchObject({
    value: 'success',
    context: { fetchErrors: [], people: filteredFetchData },
  })
  expect(fetchMock).toHaveBeenCalledTimes(3)

  // 8. CHECK THE THIRD FETCH' QUERY
  expect(fetchMock).toHaveBeenLastCalledWith(
    // machine' context
    expect.objectContaining({ filter: expect.objectContaining({ query }) }),
    // machine' states and invokeMeta, useless for the purpose of the tests
    expect.anything(),
    expect.anything(),
  )
})
```
</details>
<details>
  <summary>Second approach example</summary>

```js
it('When retrying, should retry with the last query', async () => {
  // ARRANGE
  const query = 'Ann Henry'
  const {
    service,
    fetchMock,
    rejectFetchMock,
    resolveFetchMock,
    waitDebouncedFetch,
  } = createMockedMachine(1)

  // ACT
  service.send({ type: 'START' })
  resolveFetchMock(defaultFetchData)
  service.send({ type: 'SET_QUERY', query })
  await waitDebouncedFetch()
  rejectFetchMock(error)
  service.send({ type: 'RETRY' })
  await waitDebouncedFetch()

  // ASSERT
  expect(fetchMock).toHaveBeenLastCalledWith(
    // machine' context
    expect.objectContaining({ filter: expect.objectContaining({ query }) }),
    // machine' states and invokeMeta, useless for the purpose of the tests
    expect.anything(),
    expect.anything(),
  )
})
```
</details>
<details>
  <summary>Third approach example</summary>

```js
it('When the "FAILURE" event occurs, should move from the "fetch" state to the "failure" one', () => {
  // ARRANGE
  const { machineMock } = createMockedMachine()

  // ACT
  const actualState = machineMock.transition('fetch', {
    type: 'FAILURE',
    data: error,
  })

  // ASSERT
  expect(actualState).toMatchObject({
    value: 'failure',
    context: { fetching: false, fetchErrors: [error] },
  })
})
```
</details>


### Consuming the machine from React


#### Wrapper

The render tree must be wrapped by the `MachineRoot` component, that stores the running machine (the service) in a React Context.

#### Accessing the machine

The fact that the running machine is available through a React Context is an implementation detail that the consumers must be unaware of. All the components that need to connect to the running machine must use the exported `useMachine` hook, which completely hides the usage of the React Context. This is particularly helpful for future refactors.


## Features
The proposed Finite State Macihne is strictly coupled to the UI of the People list. It allows:

- to fetch the People when the machine starts

- to change the filter (composed by the `query` and the `employment` type)

- to know if the last fetch went well or not

- to access the fetched People

- to access the queue of errors that happened in the last fetches, if they failed

- to retry the previously failed request

- to cancel the previous requests. The search/filter inputs aren't disabled when there is an ongoing fetch, cancelling the previous fetches avoids managing their race conditions

Features included even if not necessary:

- debouncing the fetch: the design specs report that "The search is made on value change.". Hence, no debounce is required. This is unusual behavior for a front-end app, leading to a lot of requests and network traffic. I would propose to add a 300 milliseconds-delay to the search to avoid the user triggering a fetch at every keystroke. Anyway: at the moment, the debounce logic is implemented, but the debounce delay is set to 0 ms

Features not included that could be considered in the future:

- forcing the fetch: this feature will become necessary only if
  - the debounce will be used, changing the delay from 0 ms to something noticeable (ex. 800+ ms)
  - the People list will present to the user a way to force the fetch or something that requires triggering an immediate fetch


## Notes
The default filter includes both the employees and the contractors.
