### PR TITLE
fix(components): Fix table padding

### DIFF
--- a/src/components/Table/Table.jsx
+++ b/src/components/Table/Table.jsx
@@ -16,7 +16,7 @@ export const TableRow = styled.tr``;
 
 export const TableThCell = styled.th`
   white-space: nowrap;
-  padding: 18px 0 18px 16px;
+  padding: 18px 16px 18px 16px;
   text-align: left;
   font-size: 0.6875rem;
   text-transform: uppercase;


### PR DESCRIPTION
# Table padding

This is a small CSS fix that sets the same right/left padding of the cells to the heads.

The padding of the cells is
```css
padding: 8px 16px 8px 16px;
```
while the padding of the heads was
```css
padding: 18px 0 18px 16px;
```

I noticed it while working on the People list when a column is right-aligned. In the below screenshot, you can see how the table looks like before and after the fix.

![132944258-66af7ce0-4541-4239-ad93-5d997a5cd0ca](https://user-images.githubusercontent.com/173663/136150605-898a9283-7d74-4efa-981a-51650c811dad.jpg)

