### PR TITLE
feat(domain): Add currency utilities

### DIFF
--- a/src/pages/People/types.js
+++ b/src/pages/People/types.js
@@ -3,6 +3,8 @@
 // ---------------------------------------------------------------
 // DOMAIN
 
+/** @typedef {import('../../utils/currency.js').Currency} Currency */
+
 /**
  * @typedef {Object} People
  * @property {number} id
@@ -14,8 +16,6 @@
  * @property {Employment} employment
  *
  * @typedef {'employee' | 'contractor'} Employment
- *
- * @typedef {'EUR' | 'USD' | 'GBP'} Currency
  */
 
 // ---------------------------------------------------------------

--- a/src/utils/currency.js
+++ b/src/utils/currency.js
@@ -1,0 +1,77 @@
+// @ts-check
+
+// Currency utilities
+
+/**
+ * @typedef {'EUR' | 'USD' | 'GBP'} Currency
+ * @typedef {'it-IT' | 'en-US' | 'en-GB'} Locale
+ */
+
+/**
+ * @typedef {Object} Props
+ * @property {Currency} currency
+ * @property {number} salary
+ */
+
+/**
+ * Get the currency symbol for the given currency code.
+ *
+ * @param {Currency} currency
+ */
+export function getCurrencySymbol(currency) {
+  switch (currency) {
+    case 'EUR':
+      return '€';
+
+    case 'USD':
+      return '$';
+
+    case 'GBP':
+      return '£';
+
+    default:
+      return '';
+  }
+}
+
+/**
+ * Stringify the salary based on the country of the currency code.
+ * @example
+ * // returns 10.000,00
+ * getSalary('EUR', 10000)
+ * // returns 10,000.00
+ * getSalary('USD', 10000)
+ *
+ * @param {Currency} currency
+ * @param {number} salary
+ */
+export function getSalary(currency, salary) {
+  switch (currency) {
+    case 'USD':
+      return salary.toLocaleString(getLocale(currency), { minimumFractionDigits: 2 });
+
+    case 'EUR':
+    case 'GBP':
+      return salary.toLocaleString(getLocale(currency), { minimumFractionDigits: 2 });
+
+    default:
+      return salary.toString();
+  }
+}
+
+/**
+ * @param {Currency} currency
+ */
+function getLocale(currency) {
+  switch (currency) {
+    case 'EUR':
+      return 'it-IT';
+
+    case 'GBP':
+      return 'en-GB';
+
+    case 'USD':
+    default:
+      return 'en-US';
+  }
+}


### PR DESCRIPTION
# Currency utilities

The design specs require printing the salary:
- with the currency symbol
- with the locale of the currency itself

<img width="136" alt="132945525-f35e3c00-599c-45c4-80f1-0b15ba286ed0" src="https://user-images.githubusercontent.com/173663/136150649-40d15718-04d9-4362-a7f1-0cf370067f54.png">

that's why I introduced some common utilities to format the currency.

## Browser compatibility

`toLocaleSting` is [widely compatible](https://caniuse.com/?search=toLocaleString).
