### PR TITLE
feat(app): Add the People list components for the success state

### DIFF
--- a/src/pages/People/components/PeopleList/components/Employee.jsx
+++ b/src/pages/People/components/PeopleList/components/Employee.jsx
@@ -1,0 +1,46 @@
+// @ts-check
+
+/** @typedef {import('../../../types.js').People} People */
+
+import styled from 'styled-components';
+
+import Link from 'components/Link';
+import { TableCell, TableRow } from 'components/Table';
+
+import { Salary } from './Salary';
+
+const CapitalizedTableCell = styled(TableCell)`
+  // @see https://caniuse.com/?search=text-transform
+  text-transform: capitalize;
+`;
+
+/**
+ * @typedef {Object} Props
+ * @property {People} employee
+ */
+
+/**
+ * Render the employee and his/her data.
+ *
+ * @param {Props} props
+ */
+export function Employee(props) {
+  const {
+    employee: { id, name, jobTitle, employment, country, currency, salary },
+  } = props;
+
+  return (
+    <TableRow data-testid={`people-list-row-${id}`}>
+      <TableCell>{name}</TableCell>
+      <TableCell>{jobTitle}</TableCell>
+      <CapitalizedTableCell>{employment}</CapitalizedTableCell>
+      <TableCell>{country}</TableCell>
+      <TableCell align="right">
+        <Salary currency={currency} salary={salary} />
+      </TableCell>
+      <TableCell align="right">
+        <Link href={`/people/edit/${id}`}>Edit</Link>
+      </TableCell>
+    </TableRow>
+  );
+}

--- a/src/pages/People/components/PeopleList/components/Salary.jsx
+++ b/src/pages/People/components/PeopleList/components/Salary.jsx
@@ -1,0 +1,26 @@
+// @ts-check
+
+/** @typedef {import('../../../../../utils/currency.js').Currency} Currency */
+
+import { getCurrencySymbol, getSalary } from '../../../../../utils/currency.js';
+
+/**
+ * @typedef {Object} Props
+ * @property {Currency} currency
+ * @property {number} salary
+ */
+
+/**
+ * Render the salary.
+ *
+ * @param {Props} props
+ */
+export function Salary(props) {
+  const { currency, salary } = props;
+
+  return (
+    <>
+      {getCurrencySymbol(currency)} {currency} {getSalary(currency, salary)}
+    </>
+  );
+}

--- a/src/pages/People/components/PeopleList/components/TableBody.jsx
+++ b/src/pages/People/components/PeopleList/components/TableBody.jsx
@@ -1,0 +1,27 @@
+// @ts-check
+
+/** @typedef {import('../../../types.js').People} People */
+
+import { Employee } from './Employee';
+
+/**
+ * @typedef {Object} Props
+ * @property {People[]} people
+ */
+
+/**
+ * Render the body of the People list.
+ *
+ * @param {Props} props
+ */
+export function TableBody(props) {
+  const { people } = props;
+
+  return (
+    <tbody data-testid="people-list-table">
+      {people.map((p) => (
+        <Employee key={p.id} employee={p} />
+      ))}
+    </tbody>
+  );
+}

--- a/src/pages/People/components/PeopleList/components/TableHeader.jsx
+++ b/src/pages/People/components/PeopleList/components/TableHeader.jsx
@@ -1,0 +1,25 @@
+// @ts-check
+
+import { TableThCell } from 'components/Table';
+
+/**
+ * Render the header of the People list.
+ */
+export function TableHeader() {
+  return (
+    <thead>
+      <tr>
+        <TableThCell style={{ width: '25%' }}>Name</TableThCell>
+        <TableThCell style={{ width: '20%' }}>Role</TableThCell>
+        <TableThCell style={{ width: '15%' }}>Type</TableThCell>
+        <TableThCell style={{ width: '15%' }}>Country</TableThCell>
+        <TableThCell style={{ width: '15%' }} align="right">
+          Salary
+        </TableThCell>
+        <TableThCell style={{ width: '10%' }} align="right">
+          {/* Link column */}
+        </TableThCell>
+      </tr>
+    </thead>
+  );
+}


### PR DESCRIPTION
### Preface

_This is the first PR of a series that leads to the whole People page. Following is a screenshot to provide context over the components that I'm going to introduce with this PR and the next ones._

![133379452-91e99900-3354-43cb-b8ec-b13e4b35a4d6](https://user-images.githubusercontent.com/173663/136151051-fbe92ac1-c85d-482e-bc71-747c5340a3e5.jpg)



# People list components for the success state

This PR includes the components that render the employees list.


![133379496-1b454ff3-8e08-4f51-9cfb-ca15ac48eef3](https://user-images.githubusercontent.com/173663/136151062-930f59e3-7df4-4c3a-8604-45bae1941a26.jpg)


All the components included in this PR are the leaves of the render tree. The goal is to have dumb and unconnected components. The `<PeopleList />` parent (that will be introduced in the next PRs) will connect to the machine, providing the `<TableBody />` and `<TableHeader />` components the data to render.

## Notes
- the percentages of the table' columns are calculated starting from the [Design Specs](https://www.figma.com/file/ypsdDsJCUYq75YuwHl0tQ3/FE-code-exercise-NoriSte-clone?node-id=3329%3A1281), then adapted, rounded, and a bit simplified to best fit how the browser renders them