### PR TITLE
feat(app): Add the People list components for the fetching, no-results, and error states

### DIFF
--- a/src/pages/People/components/PeopleList/components/FetchFailed.jsx
+++ b/src/pages/People/components/PeopleList/components/FetchFailed.jsx
@@ -1,0 +1,39 @@
+// @ts-check
+
+import styled from 'styled-components';
+import Link from 'components/Link';
+
+const Wrapper = styled.div`
+  // --------------------------------------------
+  // DIMENSIONS ---------------------------------
+  width: 100%;
+  min-height: 200px;
+
+  // --------------------------------------------
+  // FLEX ---------------------------------------
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 10px;
+`;
+
+/**
+ * @typedef {Object} Props
+ * @property {() => void} onRetry
+ */
+
+/**
+ * Render a generic error message and a retry button.
+ *
+ * @param {Props} props
+ */
+export function FetchFailed(props) {
+  const { onRetry } = props;
+
+  return (
+    <Wrapper>
+      <p>An error occurred.</p>
+      <Link onClick={onRetry}>Retry</Link>
+    </Wrapper>
+  );
+}

--- a/src/pages/People/components/PeopleList/components/Loading.jsx
+++ b/src/pages/People/components/PeopleList/components/Loading.jsx
@@ -1,0 +1,29 @@
+// @ts-check
+
+import styled from 'styled-components';
+
+import LoadingLogo from 'components/LoadingLogo';
+
+const Wrapper = styled.div`
+  // --------------------------------------------
+  // DIMENSIONS ---------------------------------
+  width: 100%;
+  min-height: 200px;
+
+  // --------------------------------------------
+  // FLEX ---------------------------------------
+  display: flex;
+  align-items: center;
+  justify-content: center;
+`;
+
+/**
+ * Render and center the Loading Logo
+ */
+export function Loading() {
+  return (
+    <Wrapper>
+      <LoadingLogo />
+    </Wrapper>
+  );
+}

--- a/src/pages/People/components/PeopleList/components/NoResults.jsx
+++ b/src/pages/People/components/PeopleList/components/NoResults.jsx
@@ -1,0 +1,27 @@
+// @ts-check
+
+import styled from 'styled-components';
+
+const Wrapper = styled.div`
+  // --------------------------------------------
+  // DIMENSIONS ---------------------------------
+  width: 100%;
+  min-height: 200px;
+
+  // --------------------------------------------
+  // FLEX ---------------------------------------
+  display: flex;
+  align-items: center;
+  justify-content: center;
+`;
+
+/**
+ * Render a "no result" text.
+ */
+export function NoResults() {
+  return (
+    <Wrapper>
+      <p>No people.</p>
+    </Wrapper>
+  );
+}


### PR DESCRIPTION
# People list components for the fetching, no-results, and error states

This PR includes three different components

## `<Loading />`
This component will be rendered every time the machine fetches the employees, either the first time or at every change of the filters.



![133382404-d7440117-7cce-4086-a455-44a0ffcfbdd2](https://user-images.githubusercontent.com/173663/136151258-c6ad322b-8bbe-4431-851c-36a55de835a1.jpg)


## `<NoResults />`
This is a component the Design Specs don't provide. That's why the UI is temporary, and I'd like to present it to the UI Designers to have their feedback.

![133382438-6520645f-27a5-4f0e-94ef-2989107a5363](https://user-images.githubusercontent.com/173663/136151281-ba351c30-c4f5-4099-9823-d0557a403834.jpg)


## `<FetchFailed />`
This is a component the Design Specs don't provide. That's why the UI is temporary and I'd like to present it to the UI Designers to have their feedback.


![133382483-e487ec29-11ef-4a0a-8761-ea58e138ca4d](https://user-images.githubusercontent.com/173663/136151296-406a7b44-bbb4-4dcf-a5c3-02967a38521c.jpg)

