### PR TITLE
feat(app): Add the PeopleList component, wired to the machine

### DIFF
--- a/src/pages/People/components/PeopleList/PeopleList.jsx
+++ b/src/pages/People/components/PeopleList/PeopleList.jsx
@@ -1,0 +1,74 @@
+// @ts-check
+
+/** @typedef {import('../../types.js').People} People */
+
+import { Table } from 'components/Table';
+
+import { usePeople } from '../../hooks/usePeople';
+import { useRetryFetch } from '../../hooks/useRetryFetch';
+import { useIsFetching } from '../../hooks/useIsFetching';
+import { useFetchErrors } from '../../hooks/useFetchErrors';
+
+import { Loading } from './components/Loading';
+import { NoResults } from './components/NoResults';
+import { TableBody } from './components/TableBody';
+import { FetchFailed } from './components/FetchFailed';
+import { TableHeader } from './components/TableHeader';
+
+/**
+ * Render all the states of the People list.
+ *
+ * Please note that:
+ * - it doesn't manage the machine `idle` state, it takes for granted that a parent started the
+ * machine in advance
+ * - it uses the 'fetchErrors' to detect if the last fetch failed or not. This allows showing the
+ * error message also when the state is in the `debounceFetch` but contains errors
+ *
+ */
+export function PeopleList() {
+  const people = usePeople();
+  const isFetching = useIsFetching();
+  const fetchFailed = useFetchErrors().length > 0;
+
+  const retry = useRetryFetch();
+
+  if (isFetching) {
+    return (
+      <>
+        <Table>
+          <TableHeader />
+        </Table>
+        <Loading />
+      </>
+    );
+  }
+
+  if (fetchFailed) {
+    return (
+      <>
+        <Table>
+          <TableHeader />
+        </Table>
+        <FetchFailed onRetry={retry} />
+      </>
+    );
+  }
+
+  if (people.length === 0) {
+    return (
+      <>
+        <Table>
+          <TableHeader />
+        </Table>
+        <NoResults />
+      </>
+    );
+  }
+
+  return (
+    <Table>
+      <TableHeader />
+      <TableBody people={people} />
+    </Table>
+  );
+}

--- a/src/pages/People/components/PeopleList/index.js
+++ b/src/pages/People/components/PeopleList/index.js
@@ -1,0 +1,1 @@
+export * from './PeopleList';

--- a/src/pages/People/hooks/useFetchErrors.js
+++ b/src/pages/People/hooks/useFetchErrors.js
@@ -1,0 +1,11 @@
+// @ts-check
+
+import { useSelector } from '@xstate/react';
+import { useMachine } from '../machine/MachineRoot';
+
+/**
+ * Get the fetch error.
+ */
+export function useFetchErrors() {
+  return useSelector(useMachine(), (state) => state.context.fetchErrors);
+}

--- a/src/pages/People/hooks/useIsFetching.js
+++ b/src/pages/People/hooks/useIsFetching.js
@@ -1,0 +1,11 @@
+// @ts-check
+
+import { useSelector } from '@xstate/react';
+import { useMachine } from '../machine/MachineRoot';
+
+/**
+ * Return if the machine is fetching the people or not.
+ */
+export function useIsFetching() {
+  return useSelector(useMachine(), (state) => state.context.fetching);
+}

--- a/src/pages/People/hooks/usePeople.js
+++ b/src/pages/People/hooks/usePeople.js
@@ -1,0 +1,11 @@
+// @ts-check
+
+import { useSelector } from '@xstate/react';
+import { useMachine } from '../machine/MachineRoot';
+
+/**
+ * Get the fetched people.
+ */
+export function usePeople() {
+  return useSelector(useMachine(), (state) => state.context.people);
+}

--- a/src/pages/People/hooks/useRetryFetch.js
+++ b/src/pages/People/hooks/useRetryFetch.js
@@ -1,0 +1,15 @@
+// @ts-check
+
+import { useCallback } from 'react';
+import { useMachine } from '../machine/MachineRoot';
+
+/**
+ * Allow retrying the fetch after a failure.
+ */
+export function useRetryFetch() {
+  const { send } = useMachine();
+
+  return useCallback(() => {
+    send({ type: 'RETRY' });
+  }, [send]);
+}


### PR DESCRIPTION
# The `<PeopleList />` component

This is the wrapper that renders the different UI introduced with #12 and #13.

![133383256-4cf70542-9bac-466b-b30c-a234b4ed7e08](https://user-images.githubusercontent.com/173663/136151403-5d8d1217-0537-4932-a1e6-ecbf3623dc81.jpg)


## Design decisions

### Clear JSX

This is a subjective topic. In my opinion, many JSXs are hard to read and fail to expose the different states they render.

That's why I avoided writing a JSX like this
```jsx
return (
  <>
    <Table>
      <TableHeader />

      {people.length > 0 && <TableBody people={people} />}
    </Table>

    {isFetching && <Loading />}
    {fetchFailed && <FetchFailed onRetry={retry} />}
    {people.length === 0 && <NoResults />}
  </>
);
```

and I opted for a longer, but clearer version.
```jsx
if (isFetching) {
  return (
    <>
      <Table>
        <TableHeader />
      </Table>
      <Loading />
    </>
  );
}

if (fetchFailed) {
  return (
    <>
      <Table>
        <TableHeader />
      </Table>
      <FetchFailed onRetry={retry} />
    </>
  );
}

if (people.length === 0) {
  return (
    <>
      <Table>
        <TableHeader />
      </Table>
      <NoResults />
    </>
  );
}

return (
  <Table>
    <TableHeader />
    <TableBody people={people} />
  </Table>
);
```

At this point, why not going for some dedicated components? Something like
```jsx
if (isFetching) {
  return <FetchingState />;
}

if (fetchFailed) {
  return <FailedState onRetry={retry} />;
}

if (people.length === 0) {
  return <NoResultsState />;
}

return <ListState people={people} />;
```

The rationale behind this decision is the simplicity of the components to render. Until they get more complicated, I don't feel the need to add another abstraction layer. Instead, I value that the reader can get a snap of the common parts among the different states.

If the components get more complicated, they will be refactored.

### Custom hooks

Hooks are great for everything but having readable components code. The reality is that React hooks are meant to be hidden through custom hooks that speak for their purpose through their name. An example is the `useStartMachine` hook that will be part of the next PR, having a component that does
```jsx
useStartMachine()
```
instead of
```js
useEffect(() => {
  send({ type: 'START' });
}, [send]);
```
is way more readable and self-explanatory. This is especially valid when there are long combinations of `useState`, `useCalback`, and triggered `useEffect`.

That's why I always move hooks-related code to custom hooks.

### Specialized hooks

The rationale behind creating separated hooks (`useFetchErrors`, `useIsFetching`, `usePeople`, `useRetryFetch`) is that the same hooks will be used singularly by other components I'm going to introduce in the next PRs.
