### PR TITLE
feat(app): Add the filter buttons and the searchfield

### DIFF
--- a/src/pages/People/components/Filters.jsx
+++ b/src/pages/People/components/Filters.jsx
@@ -1,0 +1,65 @@
+// @ts-check
+
+import { useCallback } from 'react';
+import styled from 'styled-components';
+
+import Filter from 'components/Form/Filter';
+import SearchField from 'components/Form/SearchField';
+
+import { useFilterPeople } from '../hooks/useFilterPeople';
+
+const Container = styled.div`
+  // --------------------------------------------
+  // FLEX ---------------------------------------
+  display: flex;
+  justify-content: space-between;
+
+  // --------------------------------------------
+  // BOX ----------------------------------------
+  margin-bottom: 16px;
+`;
+
+const FilterButtonsContainer = styled.span`
+  // --------------------------------------------
+  // FLEX ---------------------------------------
+  // Get the filter buttons inlined
+  display: flex;
+`;
+
+/**
+ * Render the the components that allow filtering the people.
+ */
+export function Filters() {
+  const {
+    query,
+    setQuery,
+    includeEmployees,
+    includeContractors,
+    setIncludeEmployees,
+    setIncludeContractors,
+  } = useFilterPeople();
+
+  const onQueryChange = useCallback((e) => setQuery(e.target.value), [setQuery]);
+
+  const onEmployeesChange = useCallback((e) => setIncludeEmployees(e.target.checked), [
+    setIncludeEmployees,
+  ]);
+  const onContractorsChange = useCallback((e) => setIncludeContractors(e.target.checked), [
+    setIncludeContractors,
+  ]);
+
+  return (
+    <Container>
+      <SearchField placeholder="Search employees..." value={query} onChange={onQueryChange} />
+
+      <FilterButtonsContainer>
+        <Filter checked={includeContractors} onChange={onContractorsChange}>
+          Contractor
+        </Filter>
+        <Filter checked={includeEmployees} onChange={onEmployeesChange}>
+          Employee
+        </Filter>
+      </FilterButtonsContainer>
+    </Container>
+  );
+}

--- a/src/pages/People/hooks/useFilterPeople.js
+++ b/src/pages/People/hooks/useFilterPeople.js
@@ -1,0 +1,101 @@
+// @ts-check
+
+/** @typedef {import('../types.js').Employment} Employment */
+
+import { useEffect, useCallback } from 'react';
+import { useSelector } from '@xstate/react';
+
+import { useMachine } from '../machine/MachineRoot';
+
+/**
+ * Get the current filter properties and the callbacks to set the next ones.
+ */
+export function useFilterPeople() {
+  const service = useMachine();
+  const { send } = service;
+
+  const machineFilter = useSelector(service, (state) => {
+    // The current state of the UI filters the user see is:
+    // - stored in the current filter (machine's `filter`) when there isn't an ongoing debounced fetch
+    // - stored in the debounced filter (machine's `debounceFilter`) when there is an ongoing debounced fetch
+    return state.context.debounceFilter || state.context.filter;
+  });
+
+  const query = machineFilter.query;
+  const employment = machineFilter.employment;
+
+  const includeContractors = employment.includes('contractor');
+  const includeEmployees = employment.includes('employee');
+
+  /** @type {(query:string) => void} */
+  const setQuery = useCallback(
+    (value) => {
+      send({
+        type: 'SET_FILTER',
+        filter: { employment, query: value },
+      });
+    },
+    [send, employment]
+  );
+
+  /** @type {(includeContractors:boolean) => void} */
+  const setIncludeContractors = useCallback(
+    (value) => {
+      send({
+        type: 'SET_FILTER',
+        filter: { query, employment: getEmployment(includeEmployees, value) },
+      });
+    },
+    [send, query, includeEmployees]
+  );
+
+  /** @type {(includeEmployees:boolean) => void} */
+  const setIncludeEmployees = useCallback(
+    (value) => {
+      send({
+        type: 'SET_FILTER',
+        filter: { query, employment: getEmployment(value, includeContractors) },
+      });
+    },
+    [send, query, includeContractors]
+  );
+
+  return {
+    query,
+    setQuery,
+    includeEmployees,
+    includeContractors,
+    setIncludeEmployees,
+    setIncludeContractors,
+  };
+}
+
+/** @type {Employment[]} */
+const noEmployments = [];
+/** @type {Employment[]} */
+const employeesOnly = ['employee'];
+/** @type {Employment[]} */
+const contractorsOnly = ['contractor'];
+/** @type {Employment[]} */
+const allEmployments = ['employee', 'contractor'];
+
+/**
+ * Get the correct employment array based ont he users input.
+ * @param {boolean} includeEmployees
+ * @param {boolean} includeContractors
+ */
+function getEmployment(includeEmployees, includeContractors) {
+  if (includeEmployees && includeContractors) {
+    return allEmployments;
+  }
+
+  if (includeContractors) {
+    return contractorsOnly;
+  }
+
+  if (includeEmployees) {
+    return employeesOnly;
+  }
+
+  return noEmployments;
+}


### PR DESCRIPTION
# People filters

Allow querying the People and filtering employees and contractors.

![133731365-c18df4a8-0bde-480c-bf7a-f247345fca33](https://user-images.githubusercontent.com/173663/136151478-11d388fb-1ec2-4abf-a865-50132b9b7fdd.jpg)


Here's the first usage of the components introduced with #3 and #4.

## The `useFilterPeople` custom hook

Its main purposes are:

- retrieving the initial filters from the machine and set the UI accordingly (see #9's `initialContext`)

- keeping the UI 1:1 aligned with the current state of the machine filters: the input fields don't need to have some private `useState` because, at the moment, the machine' context contains the same data (through `filter` and ` debounceFilter`). No risk to have discrepancies or stale data between the input fields and the machine here.

- creating the callbacks that compose the next filter, starting from the prev one: using `immer` would probably get the code more readable, but adding a dependency to simplify a bunch of lines of code isn't worth it, in my opinion.

Please note: I know that most React apps don't need to memoize everything, but I always encourage developers to use `useCallbacks` instead of inline or always-regenerated callbacks. The main reason is the different levels of experience in the teams. The developers have different levels of understanding of how the React hooks work and how always-new references could impact others `useCallbacks` and `useEffect`, leading to wide usage of `useRef` to sweep under the carpet.

So the main reason for using `useCallback` here isn't about performance, but it's about avoiding always-new references involuntarily triggering other `useEffect` down in the render tree. That's not the case with this simple app, but it's more about scaling the app without surprises and long debugging hours or having `useRef` spreading in every custom hook.

## The `<Filters />` component

Connects the input fields `onChange` with the actions returned by `useFilterPeople`.


