### PR TITLE
feat(app): Add the People page header

### DIFF
--- a/src/pages/People/components/AddMemberButton.jsx
+++ b/src/pages/People/components/AddMemberButton.jsx
@@ -1,0 +1,34 @@
+// @ts-check
+
+import styled from 'styled-components';
+
+import { ReactComponent as Icon } from 'theme/icons/user.svg';
+import BaseButton from 'components/Button';
+
+const ButtonContainer = styled.div`
+  // --------------------------------------------
+  // APPEARANCE ---------------------------------
+  // filter hugs the content edges instead of applying the shadow to to the box of the children
+  // see: https://css-tricks.com/almanac/properties/b/box-shadow/#comparison-with-filter-drop-shadow
+  filter: drop-shadow(var(--shadow-btnIrisPurple));
+`;
+
+const Button = styled(BaseButton)`
+  // --------------------------------------------
+  // ICON ---------------------------------------
+  svg {
+    fill: var(--colors-blank);
+    margin-right: 10px;
+  }
+`;
+
+export function AddMemberButton() {
+  return (
+    <ButtonContainer>
+      <Button>
+        <Icon />
+        Add member
+      </Button>
+    </ButtonContainer>
+  );
+}

--- a/src/pages/People/components/PageHeader.jsx
+++ b/src/pages/People/components/PageHeader.jsx
@@ -1,0 +1,35 @@
+// @ts-check
+
+import styled from 'styled-components';
+
+import { usePeople } from '../hooks/usePeople';
+import { useIsFetching } from '../hooks/useIsFetching';
+
+import { PageTitle } from './PageTitle';
+import { AddMemberButton } from './AddMemberButton';
+
+const Container = styled.div`
+  // --------------------------------------------
+  // FLEX ---------------------------------------
+  display: flex;
+  justify-content: space-between;
+
+  // --------------------------------------------
+  // BOX ----------------------------------------
+  margin-bottom: 32px;
+`;
+
+/**
+ * Render everything that comes before the People list.
+ */
+export function PageHeader() {
+  const people = usePeople();
+  const fetchingPeople = useIsFetching();
+
+  return (
+    <Container>
+      <PageTitle fetchingPeople={fetchingPeople} peopleAmount={people.length} />
+      <AddMemberButton />
+    </Container>
+  );
+}

--- a/src/pages/People/components/PageTitle.jsx
+++ b/src/pages/People/components/PageTitle.jsx
@@ -1,0 +1,40 @@
+// @ts-check
+
+import Text, { TextLight } from 'components/Text';
+
+/**
+ * @typedef {Object} Props
+ * @property {number} peopleAmount
+ * @property {boolean} fetchingPeople
+ */
+
+/**
+ * Render the page title.
+ *
+ * @param {Props} props
+ */
+export function PageTitle(props) {
+  const { peopleAmount, fetchingPeople } = props;
+
+  if (fetchingPeople) {
+    return (
+      // @ts-expect-error `size` isn't typed yet
+      <Text size="h1" as="h1">
+        People
+      </Text>
+    );
+  }
+
+  return (
+    <>
+      {/* @ts-expect-error `size` isn't typed yet */}
+      <Text size="h1" as="h1">
+        People
+        <TextLight style={{ marginLeft: '8px' }}>
+          {/* @ts-expect-error `size` isn't typed yet */}
+          <Text size="bodySmall">{peopleAmount} Employees</Text>
+        </TextLight>
+      </Text>
+    </>
+  );
+}

--- a/src/theme/GlobalStyles.js
+++ b/src/theme/GlobalStyles.js
@@ -2,14 +2,16 @@ import { normalize } from 'styled-normalize';
 import { createGlobalStyle } from 'styled-components';
 import fontFaces from './fonts/styles';
 import colors from './colors';
+import shadows from './shadows';
 
 const GlobalStyles = createGlobalStyle`
   ${normalize}
 
   ${fontFaces}
-  
+
   :root {
     ${colors}
+    ${shadows}
 
     --font-primary: "Inter", sans-serif;
     --layout-width: 1100px;

--- a/src/theme/shadows.js
+++ b/src/theme/shadows.js
@@ -1,0 +1,7 @@
+import { css } from 'styled-components';
+
+const shadow = css`
+  --shadow-btnIrisPurple: 0px 6px 12px rgba(var(--colors-irisBlue-rgb), 0.3);
+`;
+
+export default shadow;


### PR DESCRIPTION
# The Header of the People page

Render the "Add member button" and the page title, including the number of people listed.



![133735992-6d4662a3-d64a-480e-9254-4a19ae70bd1e](https://user-images.githubusercontent.com/173663/136151570-95e42a67-4fb4-4376-977b-2274e6864844.jpg)

Please note:
- the `<PageTitle />` component follows the same "clear JSX" logic I introduced with #14, where I explained why I prefer something like
```jsx
if (fetchingPeople) {
  return (
    <Text size="h1" as="h1">
      People
    </Text>
  );
}

return (
  <>
    <Text size="h1" as="h1">
      People
      <TextLight style={{ marginLeft: '8px' }}>
        <Text size="bodySmall">{peopleAmount} Employees</Text>
      </TextLight>
    </Text>
  </>
);
```
instead of something like
```jsx
return (
  <>
    <Text size="h1" as="h1">
      People
      {!fetchingPeople && <TextLight style={{ marginLeft: '8px' }}>
        <Text size="bodySmall">{peopleAmount} Employees</Text>
      </TextLight>}
    </Text>
  </>
);
```

- I added the shadows to the theme because, in the Design Specs, I found that the shadow of the button is themed. I'd like to talk with the UI Designers to understand if they are going to move the shadows at a theme level (that makes sense, requires also adapting the existing components) or not
<img width="612" alt="Screenshot 2021-09-17 at 08 41 55" src="https://user-images.githubusercontent.com/173663/133736664-0dc985b1-3f45-44f3-bdfc-32836aa66fbf.png">

- the `{/* @ts-expect-error size isn't typed yet */}` comments are here because it's true that with #8 I introduced JSDoc to leverage IDE's autocompletion and validation, but I'd like to talk with the whole team before migrating the entire codebase. The primary rationale is that I'll push (showing pros and cons) toward TypeScript, instead of JSDoc

